### PR TITLE
feat(vpc): add vpc resource and datasource support

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -38,15 +38,15 @@ linters-settings:
   staticcheck:
     # SAxxxx checks in https://staticcheck.io/docs/configuration/options/#checks
     # Default: ["*"]
-    checks: ["all"]
+    checks: [ "all" ]
   gosimple:
     # Sxxxx checks in https://staticcheck.io/docs/configuration/options/#checks
     # Default: ["*"]
-    checks: ["all"]
+    checks: [ "all" ]
   stylecheck:
     # STxxxx checks in https://staticcheck.io/docs/configuration/options/#checks
     # Default: ["*"]
-    checks: ["all", "-ST1000", "-ST1016", "-ST1020", "-ST1021", "-ST1022"]
+    checks: [ "all", "-ST1000", "-ST1016", "-ST1020", "-ST1021", "-ST1022" ]
   gocyclo:
     # Minimal code complexity to report.
     # Default: 30 (but we recommend 10-20)
@@ -99,17 +99,17 @@ linters-settings:
       - name: var-naming
         disabled: false
         arguments:
-          - ["API", "ID", "IP", "VM", "JSON", "HTTP", "URL", "XML", "YAML", "CSS", "ACL", "CPU"] # AllowList
-          - [] # DenyList
+          - [ "API", "ID", "IP", "VM", "JSON", "HTTP", "URL", "XML", "YAML", "CSS", "ACL", "CPU" ] # AllowList
+          - [ ] # DenyList
       - name: argument-limit
         disabled: false
-        arguments: [6]
+        arguments: [ 6 ]
       - name: function-result-limit
         disabled: false
-        arguments: [4]
+        arguments: [ 4 ]
       - name: line-length-limit
         disabled: false
-        arguments: [150]
+        arguments: [ 150 ]
       - name: add-constant
         disabled: true
       - name: banned-characters
@@ -131,6 +131,8 @@ linters-settings:
       - name: flag-parameter
         disabled: true
       - name: use-any
+        disabled: true
+      - name: unchecked-type-assertion
         disabled: true
 
 issues:

--- a/README.md
+++ b/README.md
@@ -1,9 +1,8 @@
-<!-- Huawei Cloud Stack Online Provider -->
-<!-- markdownlint-disable MD001 MD005 -->
+<!-- markdownlint-disable MD001 MD005 MD033 MD013 MD041 -->
 <a href="https://www.huaweicloud.com/intl/en-us/product/huaweicloudstack.html"><img width="225px" height="38px" align="right" src="./docs/img/huaweicloudstack_log.png"></a>
 <a href="https://www.huaweicloud.com/intl/en-us/product/huaweicloudstack.html"><img width="225px" height="38px" align="left" src="https://camo.githubusercontent.com/1a4ed08978379480a9b1ca95d7f4cc8eb80b45ad47c056a7cfb5c597e9315ae5/68747470733a2f2f7777772e6461746f636d732d6173736574732e636f6d2f323838352f313632393934313234322d6c6f676f2d7465727261666f726d2d6d61696e2e737667"></a>
 <br/><br/>
-<!-- markdownlint-enable MD001 MD005 -->
+<!-- markdownlint-enable MD001 MD005 MD033  MD013 MD041 -->
 
 Huawei Cloud Stack Online Provider
 ==============================

--- a/README.md
+++ b/README.md
@@ -1,6 +1,9 @@
+<!-- Huawei Cloud Stack Online Provider -->
+<!-- markdownlint-disable MD001 MD005 -->
 <a href="https://www.huaweicloud.com/intl/en-us/product/huaweicloudstack.html"><img width="225px" height="38px" align="right" src="./docs/img/huaweicloudstack_log.png"></a>
 <a href="https://www.huaweicloud.com/intl/en-us/product/huaweicloudstack.html"><img width="225px" height="38px" align="left" src="https://camo.githubusercontent.com/1a4ed08978379480a9b1ca95d7f4cc8eb80b45ad47c056a7cfb5c597e9315ae5/68747470733a2f2f7777772e6461746f636d732d6173736574732e636f6d2f323838352f313632393934313234322d6c6f676f2d7465727261666f726d2d6d61696e2e737667"></a>
 <br/><br/>
+<!-- markdownlint-enable MD001 MD005 -->
 
 Huawei Cloud Stack Online Provider
 ==============================
@@ -39,7 +42,8 @@ Using the provider
 
 Please see the documentation at [provider usage](docs/index.md).
 
-Or you can browse the documentation within this repo [here](https://github.com/huaweicloud/terraform-provider-hcso/tree/master/docs).
+Or you can browse the documentation within this
+repo [here](https://github.com/huaweicloud/terraform-provider-hcso/tree/master/docs).
 
 Developing the Provider
 -----------------------

--- a/docs/data-sources/vpc.md
+++ b/docs/data-sources/vpc.md
@@ -1,0 +1,45 @@
+---
+subcategory: "Virtual Private Cloud (VPC)"
+---
+
+# hcso_vpc
+
+Provides details about a specific VPC.
+
+## Example Usage
+
+```hcl
+variable "vpc_name" {}
+
+data "hcso_vpc" "vpc" {
+  name = var.vpc_name
+}
+```
+
+## Argument Reference
+
+The arguments of this data source act as filters for querying the available VPCs in the current region. The given
+filters must match exactly one VPC whose data will be exported as attributes.
+
+* `region` - (Optional, String) Specifies the region in which to obtain the VPC. If omitted, the provider-level region
+  will be used.
+
+* `name` - (Optional, String) Specifies an unique name for the VPC. The value is a string of no more than 64 characters
+  and can contain digits, letters, underscores (_), and hyphens (-).
+
+* `id` - (Optional, String) Specifies the id of the VPC to retrieve.
+
+* `status` - (Optional, String) Specifies the current status of the desired VPC. The value can be CREATING, OK or ERROR.
+
+* `cidr` - (Optional, String) Specifies the cidr block of the desired VPC.
+
+* `enterprise_project_id` - (Optional, String) Specifies the enterprise project ID which the desired VPC belongs to.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `description` - The supplementary information about the VPC. The value is a string of
+  no more than 255 characters and cannot contain angle brackets (< or >).
+
+* `tags` - The key/value pairs to associate with the VPC.

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,7 +1,7 @@
 # HUAWEI CLOUD Stack Online Provider
 
-The HUAWEI CLOUD Stack Online provider is used to interact with the many resources supported by HUAWEI CLOUD Stack Online. The provider needs to be
-configured with the proper credentials before it can be used.
+The HUAWEI CLOUD Stack Online provider is used to interact with the many resources supported by HUAWEI CLOUD Stack
+Online. The provider needs to be configured with the proper credentials before it can be used.
 
 Use the navigation to the left to read about the available resources.
 
@@ -53,7 +53,8 @@ resource "hcso_vpc" "example" {
 
 ## Authentication
 
-The HUAWEI CLOUD Stack Online provider offers a flexible means of providing credentials for authentication. The following methods are
+The HUAWEI CLOUD Stack Online provider offers a flexible means of providing credentials for authentication. The
+following methods are
 supported, in this order, and explained below:
 
 * Static credentials
@@ -164,13 +165,16 @@ The following arguments are supported:
 * `region` - (Optional) This is the Huawei Cloud region. It must be provided when using `static credentials`
   authentication, but it can also be sourced from the `HCSO_REGION_NAME` environment variables.
 
-* `access_key` - (Optional) The access key of the HUAWEI CLOUD Stack Online to use. If omitted, the `HCSO_ACCESS_KEY` environment
+* `access_key` - (Optional) The access key of the HUAWEI CLOUD Stack Online to use. If omitted, the `HCSO_ACCESS_KEY`
+  environment
   variable is used.
 
-* `secret_key` - (Optional) The secret key of the HUAWEI CLOUD Stack Online to use. If omitted, the `HCSO_SECRET_KEY` environment
+* `secret_key` - (Optional) The secret key of the HUAWEI CLOUD Stack Online to use. If omitted, the `HCSO_SECRET_KEY`
+  environment
   variable is used.
 
-* `shared_config_file` - (Optional) The path to the shared config file. If omitted, the `HCSO_SHARED_CONFIG_FILE` environment
+* `shared_config_file` - (Optional) The path to the shared config file. If omitted, the `HCSO_SHARED_CONFIG_FILE`
+  environment
   variable is used.
 
 * `profile` - (Optional) The profile name as set in the shared config file. If omitted, the `HCSO_PROFILE` environment
@@ -182,7 +186,8 @@ The following arguments are supported:
 * `project_name` - (Optional) The Name of the project to login with. If omitted, the `HCSO_PROJECT_NAME` environment
   variable or `region` is used.
 
-* `domain_name` - (Optional) The Account name of IAM to scope to. If omitted, the `HCSO_DOMAIN_NAME` environment variable is used.
+* `domain_name` - (Optional) The Account name of IAM to scope to. If omitted, the `HCSO_DOMAIN_NAME` environment
+  variable is used.
 
 * `security_token` - (Optional) The security token to authenticate with a temporary security credential. If omitted,
   the `HCSO_SECURITY_TOKEN` environment variable is used.
@@ -214,9 +219,9 @@ The following arguments are supported:
 ```hcl
 provider "hcso" {
   ...
-  endpoints = {
-    ecs = "https://ecs-customizing-endpoint.com"
-  }
+endpoints = {
+  ecs = "https://ecs-customizing-endpoint.com"
+}
 }
 ```
 
@@ -238,4 +243,5 @@ In order to run the Acceptance Tests for development, the following environment 
 
 * `HCSO_SECRET_KEY` - The secret key of the HUAWEI CLOUD Stack Online to use.
 
-You should be able to use any HUAWEI CLOUD Stack Online environment to develop on as long as the above environment variables are set.
+You should be able to use any HUAWEI CLOUD Stack Online environment to develop on as long as the above environment
+variables are set.

--- a/docs/resources/vpc.md
+++ b/docs/resources/vpc.md
@@ -1,0 +1,96 @@
+---
+subcategory: "Virtual Private Cloud (VPC)"
+---
+
+# hcso_vpc
+
+Manages a VPC resource within HCSO.
+
+## Example Usage
+
+```hcl
+variable "vpc_name" {
+  default = "hcso_vpc"
+}
+
+variable "vpc_cidr" {
+  default = "192.168.0.0/16"
+}
+
+resource "hcso_vpc" "vpc" {
+  name = var.vpc_name
+  cidr = var.vpc_cidr
+}
+
+resource "hcso_vpc" "vpc_with_tags" {
+  name = var.vpc_name
+  cidr = var.vpc_cidr
+
+  tags = {
+    foo = "bar"
+    key = "value"
+  }
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region in which to create the VPC. If omitted, the
+  provider-level region will be used. Changing this creates a new VPC resource.
+
+* `name` - (Required, String) Specifies the name of the VPC. The name must be unique for a tenant. The value is a string
+  of no more than 64 characters and can contain digits, letters, underscores (_), and hyphens (-).
+
+* `cidr` - (Required, String) Specifies the range of available subnets in the VPC. The value ranges from 10.0.0.0/8 to
+  10.255.255.0/24, 172.16.0.0/12 to 172.31.255.0/24, or 192.168.0.0/16 to 192.168.255.0/24.
+
+* `description` - (Optional, String) Specifies supplementary information about the VPC. The value is a string of
+  no more than 255 characters and cannot contain angle brackets (< or >).
+
+* `secondary_cidr` - (Optional, String) Specifies the secondary CIDR block of the VPC.
+
+  -> The following secondary CIDR blocks cannot be added to a VPC: 10.0.0.0/8, 172.16.0.0/12, and 192.168.0.0/16.
+  [View the complete list of unsupported CIDR blocks](https://support.hcso.com/intl/en-us/usermanual-vpc/vpc_vpc_0007.html).
+
+* `tags` - (Optional, Map) Specifies the key/value pairs to associate with the VPC.
+
+* `enterprise_project_id` - (Optional, String, ForceNew) Specifies the enterprise project id of the VPC. Changing this
+  creates a new VPC resource.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The VPC ID in UUID format.
+
+* `status` - The current status of the VPC. Possible values are as follows: CREATING, OK or ERROR.
+
+## Timeouts
+
+This resource provides the following timeouts configuration options:
+
+* `create` - Default is 10 minutes.
+* `delete` - Default is 3 minutes.
+
+## Import
+
+VPCs can be imported using the `id`, e.g.
+
+```
+$ terraform import hcso_vpc.vpc_v1 7117d38e-4c8f-4624-a505-bd96b97d024c
+```
+
+Note that the imported state may not be identical to your resource definition when `secondary_cidr` was set.
+You you can ignore changes as below.
+
+```
+resource "hcso_vpc" "vpc_v1" {
+    ...
+
+  lifecycle {
+    ignore_changes = [ secondary_cidr ]
+  }
+}
+```

--- a/examples/vpc/basic/README.md
+++ b/examples/vpc/basic/README.md
@@ -1,0 +1,3 @@
+# Basic VPC and subnet
+
+This example provisions a basic vpc and subnet.

--- a/examples/vpc/basic/main.tf
+++ b/examples/vpc/basic/main.tf
@@ -1,0 +1,12 @@
+resource "hcso_vpc" "vpc_1" {
+  name = var.vpc_name
+  cidr = var.vpc_cidr
+}
+
+resource "hcso_vpc_subnet" "subnet_1" {
+  vpc_id      = hcso_vpc.vpc_1.id
+  name        = var.subnet_name
+  cidr        = var.subnet_cidr
+  gateway_ip  = var.subnet_gateway
+  primary_dns = var.primary_dns
+}

--- a/examples/vpc/basic/variables.tf
+++ b/examples/vpc/basic/variables.tf
@@ -1,0 +1,23 @@
+variable "vpc_name" {
+  default = "vpc-basic"
+}
+
+variable "vpc_cidr" {
+  default = "172.16.0.0/16"
+}
+
+variable "subnet_name" {
+  default = "subent-basic"
+}
+
+variable "subnet_cidr" {
+  default = "172.16.10.0/24"
+}
+
+variable "subnet_gateway" {
+  default = "172.16.10.1"
+}
+
+variable "primary_dns" {
+  default = "100.125.1.250"
+}

--- a/examples/vpc/secgroup/README.md
+++ b/examples/vpc/secgroup/README.md
@@ -1,0 +1,6 @@
+# Basic security group and rule
+
+This example provisions a basic security group with default rules and two ingress rules:
+
+* allow all inbound ICMP traffic
+* allow all inbound traffic on 443 port

--- a/examples/vpc/secgroup/main.tf
+++ b/examples/vpc/secgroup/main.tf
@@ -1,0 +1,24 @@
+resource "hcso_networking_secgroup" "secgroup_1" {
+  name        = "secgroup-basic"
+  description = "basic security group"
+}
+
+# allow ping
+resource "hcso_networking_secgroup_rule" "allow_ping" {
+  direction         = "ingress"
+  ethertype         = "IPv4"
+  protocol          = "icmp"
+  remote_ip_prefix  = "0.0.0.0/0"
+  security_group_id = hcso_networking_secgroup.secgroup_1.id
+}
+
+# allow https
+resource "hcso_networking_secgroup_rule" "allow_https" {
+  direction         = "ingress"
+  ethertype         = "IPv4"
+  protocol          = "tcp"
+  port_range_min    = 443
+  port_range_max    = 443
+  remote_ip_prefix  = "0.0.0.0/0"
+  security_group_id = hcso_networking_secgroup.secgroup_1.id
+}

--- a/examples/vpc/vip/README.md
+++ b/examples/vpc/vip/README.md
@@ -1,0 +1,3 @@
+# Basic VIP
+
+This example provisions two ecs instances with a vip.

--- a/examples/vpc/vip/main.tf
+++ b/examples/vpc/vip/main.tf
@@ -1,0 +1,52 @@
+data "hcso_availability_zones" "myaz" {}
+
+data "hcso_compute_flavors" "myflavor" {
+  availability_zone = data.hcso_availability_zones.myaz.names[0]
+  performance_type  = "normal"
+  cpu_core_count    = 2
+  memory_size       = 4
+}
+
+data "hcso_images_image" "myimage" {
+  name        = "Ubuntu 18.04 server 64bit"
+  most_recent = true
+}
+
+resource "hcso_vpc" "vpc_1" {
+  name = var.vpc_name
+  cidr = var.vpc_cidr
+}
+
+resource "hcso_vpc_subnet" "subnet_1" {
+  vpc_id      = hcso_vpc.vpc_1.id
+  name        = var.subnet_name
+  cidr        = var.subnet_cidr
+  gateway_ip  = var.subnet_gateway
+  primary_dns = var.primary_dns
+}
+
+resource "hcso_compute_instance" "mycompute" {
+  name              = "mycompute_${count.index}"
+  image_id          = data.hcso_images_image.myimage.id
+  flavor_id         = data.hcso_compute_flavors.myflavor.ids[0]
+  security_groups   = ["default"]
+  availability_zone = data.hcso_availability_zones.myaz.names[0]
+
+  network {
+    uuid = hcso_vpc_subnet.subnet_1.id
+  }
+  count = 2
+}
+
+resource "hcso_networking_vip" "vip_1" {
+  network_id = hcso_vpc_subnet.subnet_1.id
+}
+
+# associate ports to the vip
+resource "hcso_networking_vip_associate" "vip_associated" {
+  vip_id   = hcso_networking_vip.vip_1.id
+  port_ids = [
+    hcso_compute_instance.mycompute[0].network[0].port,
+    hcso_compute_instance.mycompute[1].network[0].port
+  ]
+}

--- a/examples/vpc/vip/variables.tf
+++ b/examples/vpc/vip/variables.tf
@@ -1,0 +1,23 @@
+variable "vpc_name" {
+  default = "vpc-basic"
+}
+
+variable "vpc_cidr" {
+  default = "172.16.0.0/16"
+}
+
+variable "subnet_name" {
+  default = "subent-basic"
+}
+
+variable "subnet_cidr" {
+  default = "172.16.10.0/24"
+}
+
+variable "subnet_gateway" {
+  default = "172.16.10.1"
+}
+
+variable "primary_dns" {
+  default = "100.125.1.250"
+}

--- a/internal/services/vpc/data_source_huaweicloud_vpc.go
+++ b/internal/services/vpc/data_source_huaweicloud_vpc.go
@@ -1,0 +1,147 @@
+package vpc
+
+import (
+	"context"
+	"log"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk/openstack/common/tags"
+	"github.com/chnsz/golangsdk/openstack/networking/v1/vpcs"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+func DataSourceVpcV1() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceVpcV1Read,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"id": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"name": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"cidr": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"enterprise_project_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"status": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"description": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"tags": {
+				Type:     schema.TypeMap,
+				Computed: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+			"routes": {
+				Type:       schema.TypeList,
+				Computed:   true,
+				Deprecated: "use hcso_vpc_route_table data source to get all routes",
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"destination": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"nexthop": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func dataSourceVpcV1Read(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	conf := meta.(*config.Config)
+	vpcClient, err := conf.NetworkingV1Client(conf.GetRegion(d))
+	if err != nil {
+		return diag.Errorf("error creating VPC client: %s", err)
+	}
+
+	listOpts := vpcs.ListOpts{
+		ID:                  d.Get("id").(string),
+		Name:                d.Get("name").(string),
+		Status:              d.Get("status").(string),
+		CIDR:                d.Get("cidr").(string),
+		EnterpriseProjectID: conf.DataGetEnterpriseProjectID(d),
+	}
+
+	refinedVpcs, err := vpcs.List(vpcClient, listOpts)
+	if err != nil {
+		return diag.Errorf("unable to retrieve vpcs: %s", err)
+	}
+
+	if len(refinedVpcs) < 1 {
+		return diag.Errorf("your query returned no results. " +
+			"Please change your search criteria and try again.")
+	}
+
+	if len(refinedVpcs) > 1 {
+		return diag.Errorf("your query returned more than one result." +
+			" Please try a more specific search criteria")
+	}
+
+	vpc := refinedVpcs[0]
+
+	log.Printf("[INFO] Retrieved vpc using given filter %s: %+v", vpc.ID, vpc)
+	d.SetId(vpc.ID)
+
+	d.Set("region", conf.GetRegion(d))
+	d.Set("name", vpc.Name)
+	d.Set("cidr", vpc.CIDR)
+	d.Set("enterprise_project_id", vpc.EnterpriseProjectID)
+	d.Set("status", vpc.Status)
+	d.Set("description", vpc.Description)
+
+	var s []map[string]interface{}
+	for _, route := range vpc.Routes {
+		mapping := map[string]interface{}{
+			"destination": route.DestinationCIDR,
+			"nexthop":     route.NextHop,
+		}
+		s = append(s, mapping)
+	}
+	d.Set("routes", s)
+
+	// save VirtualPrivateCloudV2 tags
+	if vpcV2Client, err := conf.NetworkingV2Client(conf.GetRegion(d)); err == nil {
+		if resourceTags, err := tags.Get(vpcV2Client, "vpcs", d.Id()).Extract(); err == nil {
+			tagmap := utils.TagsToMap(resourceTags.Tags)
+			if err := d.Set("tags", tagmap); err != nil {
+				return diag.Errorf("error saving tags to state for VPC (%s): %s", d.Id(), err)
+			}
+		} else {
+			log.Printf("[WARN] Error fetching tags of VPC (%s): %s", d.Id(), err)
+		}
+	}
+
+	return nil
+}

--- a/internal/services/vpc/resource_huaweicloud_vpc.go
+++ b/internal/services/vpc/resource_huaweicloud_vpc.go
@@ -1,0 +1,384 @@
+package vpc
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"time"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+	"github.com/chnsz/golangsdk/openstack/common/tags"
+	"github.com/chnsz/golangsdk/openstack/networking/v1/vpcs"
+
+	client "github.com/huaweicloud/huaweicloud-sdk-go-v3/services/vpc/v3"
+	v3vpc "github.com/huaweicloud/huaweicloud-sdk-go-v3/services/vpc/v3/model"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+func ResourceVirtualPrivateCloudV1() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceVirtualPrivateCloudCreate,
+		ReadContext:   resourceVirtualPrivateCloudRead,
+		UpdateContext: resourceVirtualPrivateCloudUpdate,
+		DeleteContext: resourceVirtualPrivateCloudDelete,
+		Importer: &schema.ResourceImporter{
+			StateContext: schema.ImportStatePassthroughContext,
+		},
+
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(10 * time.Minute),
+			Delete: schema.DefaultTimeout(3 * time.Minute),
+		},
+
+		Schema: map[string]*schema.Schema{ // request and response parameters
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+				Computed: true,
+			},
+			"name": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"cidr": {
+				Type:         schema.TypeString,
+				Required:     true,
+				ValidateFunc: utils.ValidateCIDR,
+			},
+			"description": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"secondary_cidr": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: utils.ValidateCIDR,
+			},
+			"enterprise_project_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+				Computed: true,
+			},
+			"status": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"routes": {
+				Type:       schema.TypeList,
+				Computed:   true,
+				Deprecated: "use hcso_vpc_route_table data source to get all routes",
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"destination": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"nexthop": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+					},
+				},
+			},
+			"tags": common.TagsSchema(),
+		},
+	}
+}
+
+func resourceVirtualPrivateCloudCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	conf := meta.(*config.Config)
+	region := conf.GetRegion(d)
+	vpcClient, err := conf.NetworkingV1Client(region)
+	if err != nil {
+		return diag.Errorf("error creating VPC client: %s", err)
+	}
+
+	createOpts := vpcs.CreateOpts{
+		Name:        d.Get("name").(string),
+		CIDR:        d.Get("cidr").(string),
+		Description: d.Get("description").(string),
+	}
+
+	epsID := common.GetEnterpriseProjectID(d, conf)
+	if epsID != "" {
+		createOpts.EnterpriseProjectID = epsID
+	}
+
+	n, err := vpcs.Create(vpcClient, createOpts).Extract()
+	if err != nil {
+		return diag.Errorf("error creating VPC: %s", err)
+	}
+
+	d.SetId(n.ID)
+	log.Printf("[DEBUG] Vpc ID: %s", n.ID)
+
+	stateConf := &resource.StateChangeConf{
+		Pending:    []string{"CREATING"},
+		Target:     []string{"ACTIVE"},
+		Refresh:    waitForVpcActive(vpcClient, n.ID),
+		Timeout:    d.Timeout(schema.TimeoutCreate),
+		Delay:      5 * time.Second,
+		MinTimeout: 3 * time.Second,
+	}
+
+	_, stateErr := stateConf.WaitForStateContext(ctx)
+	if stateErr != nil {
+		return diag.Errorf(
+			"error waiting for Vpc (%s) to become ACTIVE: %s",
+			n.ID, stateErr)
+	}
+
+	// set tags
+	tagRaw := d.Get("tags").(map[string]interface{})
+	if len(tagRaw) > 0 {
+		vpcV2Client, err := conf.NetworkingV2Client(region)
+		if err != nil {
+			return diag.Errorf("error creating VPC client: %s", err)
+		}
+		taglist := utils.ExpandResourceTags(tagRaw)
+		if tagErr := tags.Create(vpcV2Client, "vpcs", n.ID, taglist).ExtractErr(); tagErr != nil {
+			return diag.Errorf("error setting tags of VPC %q: %s", n.ID, tagErr)
+		}
+	}
+
+	if v, ok := d.GetOk("secondary_cidr"); ok {
+		v3Client, err := conf.HcVpcV3Client(region)
+		if err != nil {
+			return diag.Errorf("error creating VPC v3 client: %s", err)
+		}
+
+		extendCidr := v.(string)
+		if err := addSecondaryCIDR(v3Client, d.Id(), extendCidr); err != nil {
+			return diag.Errorf("error adding VPC secondary CIDR: %s", err)
+		}
+	}
+
+	return resourceVirtualPrivateCloudRead(ctx, d, meta)
+}
+
+// GetVpcById is a method to obtain vpc informations from special region through vpc ID.
+func GetVpcById(conf *config.Config, region, vpcId string) (*vpcs.Vpc, error) {
+	cli, err := conf.NetworkingV1Client(region)
+	if err != nil {
+		return nil, err
+	}
+
+	return vpcs.Get(cli, vpcId).Extract()
+}
+
+func resourceVirtualPrivateCloudRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	conf := meta.(*config.Config)
+	n, err := GetVpcById(conf, conf.GetRegion(d), d.Id())
+	if err != nil {
+		return common.CheckDeletedDiag(d, err, "Error obtain VPC information")
+	}
+
+	d.Set("name", n.Name)
+	d.Set("cidr", n.CIDR)
+	d.Set("description", n.Description)
+	d.Set("enterprise_project_id", n.EnterpriseProjectID)
+	d.Set("status", n.Status)
+	d.Set("region", conf.GetRegion(d))
+
+	// save route tables
+	routes := make([]map[string]interface{}, len(n.Routes))
+	for i, rtb := range n.Routes {
+		route := map[string]interface{}{
+			"destination": rtb.DestinationCIDR,
+			"nexthop":     rtb.NextHop,
+		}
+		routes[i] = route
+	}
+	d.Set("routes", routes)
+
+	// save VirtualPrivateCloudV2 tags
+	vpcV2Client, err := conf.NetworkingV2Client(conf.GetRegion(d))
+	if err != nil {
+		return diag.Errorf("error creating VPC client: %s", err)
+	}
+	if resourceTags, err := tags.Get(vpcV2Client, "vpcs", d.Id()).Extract(); err != nil {
+		log.Printf("[WARN] Error fetching tags of VPC (%s): %s", d.Id(), err)
+	} else {
+		tagmap := utils.TagsToMap(resourceTags.Tags)
+		if err := d.Set("tags", tagmap); err != nil {
+			return diag.Errorf("error saving tags to state for VPC (%s): %s", d.Id(), err)
+		}
+	}
+	return nil
+}
+
+func resourceVirtualPrivateCloudUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	conf := meta.(*config.Config)
+	region := conf.GetRegion(d)
+	vpcClient, err := conf.NetworkingV1Client(region)
+	if err != nil {
+		return diag.Errorf("error creating VPC client: %s", err)
+	}
+	vpcID := d.Id()
+	if d.HasChanges("name", "cidr", "description") {
+		updateOpts := vpcs.UpdateOpts{
+			Name: d.Get("name").(string),
+			CIDR: d.Get("cidr").(string),
+		}
+		if d.HasChange("description") {
+			desc := d.Get("description").(string)
+			updateOpts.Description = &desc
+		}
+		_, err = vpcs.Update(vpcClient, vpcID, updateOpts).Extract()
+		if err != nil {
+			return diag.Errorf("error updating VPC: %s", err)
+		}
+	}
+
+	// update tags
+	if d.HasChange("tags") {
+		vpcV2Client, err := conf.NetworkingV2Client(region)
+		if err != nil {
+			return diag.Errorf("error creating VPC client: %s", err)
+		}
+
+		tagErr := utils.UpdateResourceTags(vpcV2Client, d, "vpcs", vpcID)
+		if tagErr != nil {
+			return diag.Errorf("error updating tags of VPC %s: %s", vpcID, tagErr)
+		}
+	}
+
+	if d.HasChange("secondary_cidr") {
+		v3Client, err := conf.HcVpcV3Client(region)
+		if err != nil {
+			return diag.Errorf("error creating VPC v3 client: %s", err)
+		}
+
+		oldCidr, newCidr := d.GetChange("secondary_cidr")
+		preExtendCidr := oldCidr.(string)
+		newExtendCidr := newCidr.(string)
+
+		if preExtendCidr != "" {
+			if err := removeSecondaryCIDR(v3Client, vpcID, preExtendCidr); err != nil {
+				return diag.Errorf("error deleting VPC secondary CIDR: %s", err)
+			}
+		}
+		if newExtendCidr != "" {
+			if err := addSecondaryCIDR(v3Client, vpcID, newExtendCidr); err != nil {
+				return diag.Errorf("error adding VPC secondary CIDR: %s", err)
+			}
+		}
+	}
+
+	return resourceVirtualPrivateCloudRead(ctx, d, meta)
+}
+
+func resourceVirtualPrivateCloudDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	conf := meta.(*config.Config)
+	vpcClient, err := conf.NetworkingV1Client(conf.GetRegion(d))
+	if err != nil {
+		return diag.Errorf("error creating VPC client: %s", err)
+	}
+
+	stateConf := &resource.StateChangeConf{
+		Pending:    []string{"ACTIVE"},
+		Target:     []string{"DELETED"},
+		Refresh:    waitForVpcDelete(vpcClient, d.Id()),
+		Timeout:    d.Timeout(schema.TimeoutDelete),
+		Delay:      5 * time.Second,
+		MinTimeout: 3 * time.Second,
+	}
+
+	_, err = stateConf.WaitForStateContext(ctx)
+	if err != nil {
+		return diag.Errorf("error deleting VPC %s: %s", d.Id(), err)
+	}
+
+	d.SetId("")
+	return nil
+}
+
+func waitForVpcActive(vpcClient *golangsdk.ServiceClient, vpcId string) resource.StateRefreshFunc {
+	return func() (interface{}, string, error) {
+		n, err := vpcs.Get(vpcClient, vpcId).Extract()
+		if err != nil {
+			return nil, "", err
+		}
+
+		if n.Status == "OK" {
+			return n, "ACTIVE", nil
+		}
+
+		// If vpc status is other than Ok, send error
+		if n.Status == "DOWN" {
+			return nil, "", fmt.Errorf("VPC status: '%s'", n.Status)
+		}
+
+		return n, n.Status, nil
+	}
+}
+
+func waitForVpcDelete(vpcClient *golangsdk.ServiceClient, vpcId string) resource.StateRefreshFunc {
+	return func() (interface{}, string, error) {
+		r, err := vpcs.Get(vpcClient, vpcId).Extract()
+		if err != nil {
+			if _, ok := err.(golangsdk.ErrDefault404); ok {
+				log.Printf("[INFO] Successfully delete VPC %s", vpcId)
+				return r, "DELETED", nil
+			}
+			return r, "ACTIVE", err
+		}
+
+		err = vpcs.Delete(vpcClient, vpcId).ExtractErr()
+		if err != nil {
+			if _, ok := err.(golangsdk.ErrDefault404); ok {
+				log.Printf("[INFO] Successfully delete VPC %s", vpcId)
+				return r, "DELETED", nil
+			}
+			if errCode, ok := err.(golangsdk.ErrUnexpectedResponseCode); ok {
+				if errCode.Actual == 409 {
+					return r, "ACTIVE", nil
+				}
+			}
+			return r, "ACTIVE", err
+		}
+
+		return r, "ACTIVE", nil
+	}
+}
+
+func addSecondaryCIDR(cli *client.VpcClient, vpcID, cidr string) error {
+	reqBody := v3vpc.AddVpcExtendCidrRequestBody{
+		Vpc: &v3vpc.AddExtendCidrOption{
+			ExtendCidrs: []string{cidr},
+		},
+	}
+	reqOpts := v3vpc.AddVpcExtendCidrRequest{
+		VpcId: vpcID,
+		Body:  &reqBody,
+	}
+
+	log.Printf("[DEBUG] add secondary CIDR %s into VPC %s", cidr, vpcID)
+	_, err := cli.AddVpcExtendCidr(&reqOpts)
+	return err
+}
+
+func removeSecondaryCIDR(cli *client.VpcClient, vpcID, preCidr string) error {
+	reqBody := v3vpc.RemoveVpcExtendCidrRequestBody{
+		Vpc: &v3vpc.RemoveExtendCidrOption{
+			ExtendCidrs: []string{preCidr},
+		},
+	}
+	reqOpts := v3vpc.RemoveVpcExtendCidrRequest{
+		VpcId: vpcID,
+		Body:  &reqBody,
+	}
+
+	log.Printf("[DEBUG] Remove secondary CIDR %s from VPC %s", preCidr, vpcID)
+	_, err := cli.RemoveVpcExtendCidr(&reqOpts)
+	return err
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
This PR is used to add vpc resource and vpc data-source.
 If we add these resources to the hcso project, users can use and test vpc resources.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
add vpc resource and datasource support
```

## PR Checklist

* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./internal' TESTARGS='-run=TestAccSomethingV0_basic'
...
=== RUN   TestAccSomethingV0_basic
--- PASS: TestAccSomethingV0_basic (70.75s)
PASS
ok      github.com/huaweicloud/terraform-provider-hcso/internal       70.796s
```
