### PR TITLE
feat(vpc): add vpc secgroup resource and datasource support.

### DIFF
--- a/docs/data-sources/networking_port.md
+++ b/docs/data-sources/networking_port.md
@@ -1,0 +1,51 @@
+---
+subcategory: "Virtual Private Cloud (VPC)"
+---
+
+# hcso_networking_port
+
+Use this data source to get the ID of an available Huawei Cloud Stack Online port.
+
+## Example Usage
+
+```hcl
+data "hcso_networking_port" "port_1" {
+  network_id = var.network_id
+  fixed_ip   = "192.168.0.100"
+}
+```
+
+## Argument Reference
+
+* `region` - (Optional, String) Specifies the region in which to obtain the port. If omitted, the provider-level region
+  will be used.
+
+* `port_id` - (Optional, String) Specifies the ID of the port.
+
+* `network_id` - (Optional, String) Specifies the ID of the network the port belongs to.
+
+* `fixed_ip` - (Optional, String) Specifies the port IP address filter.
+
+* `mac_address` - (Optional, String) Specifies the MAC address of the port.
+
+* `status` - (Optional, String) Specifies the status of the port.
+
+* `security_group_ids` - (Optional, List) The list of port security group IDs to filter.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID in UUID format.
+
+* `name` - The name of the port.
+
+* `device_owner` - The device owner of the port.
+
+* `device_id` - The ID of the device the port belongs to.
+
+* `all_allowed_ips` - The collection of allowed IP addresses on the port.
+
+* `all_fixed_ips` - The collection of Fixed IP addresses on the port.
+
+* `all_security_group_ids` - The collection of security group IDs applied on the port.

--- a/docs/data-sources/networking_secgroups.md
+++ b/docs/data-sources/networking_secgroups.md
@@ -1,0 +1,56 @@
+---
+subcategory: "Virtual Private Cloud (VPC)"
+---
+
+# hcso_networking_secgroups
+
+Use this data source to get the list of the available Huawei Cloud Stack Online security groups.
+
+## Example Usage
+
+### Filter the list of security groups by a description keyword
+
+```hcl
+variable "key_word" {}
+
+data "hcso_networking_secgroups" "test" {
+  description = var.key_word
+}
+```
+
+## Argument Reference
+
+* `region` - (Optional, String) Specifies the region in which to obtain the security group list.
+  If omitted, the provider-level region will be used.
+
+* `id` - (Optional, String) Specifies the id of the desired security group.
+
+* `name` - (Optional, String) Specifies the name of the security group.
+
+* `description` - (Optional, String) Specifies the description of the security group. The security groups can be
+  filtered by keywords in the description.
+
+* `enterprise_project_id` - (Optional, String) Specifies the enterprise project ID of the security group.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID.
+
+* `security_groups` - The list of security groups. The [object](#security_groups) is documented below.
+
+<a name="security_groups"></a>
+The `security_groups` block supports:
+
+* `id` - The security group ID.
+
+* `description`- The description of the security group.
+
+* `name` - The name of the security group.
+
+* `enterprise_project_id` - The enterprise project ID of the security group.
+
+* `created_at` - The creation time, in UTC format.
+
+* `updated_at` - The last update time, in UTC format.

--- a/docs/data-sources/vpc_peering_connection.md
+++ b/docs/data-sources/vpc_peering_connection.md
@@ -1,0 +1,58 @@
+---
+subcategory: "Virtual Private Cloud (VPC)"
+---
+
+# hcso_vpc_peering_connection
+
+The VPC Peering Connection data source provides details about a specific VPC peering connection.
+
+## Example Usage
+
+```hcl
+data "hcso_vpc" "vpc" {
+  name = "vpc"
+}
+
+data "hcso_vpc" "peer_vpc" {
+  name = "peer_vpc"
+}
+
+data "hcso_vpc_peering_connection" "peering" {
+  vpc_id      = data.hcso_vpc.vpc.id
+  peer_vpc_id = data.hcso_vpc.peer_vpc.id
+}
+
+resource "hcso_vpc_route" "vpc_route" {
+  type        = "peering"
+  nexthop     = data.hcso_vpc_peering_connection.peering.id
+  destination = "192.168.0.0/16"
+  vpc_id      = data.hcso_vpc.vpc.id
+}
+```
+
+## Argument Reference
+
+The arguments of this data source act as filters for querying the available VPC peering connection. The given filters
+must match exactly one VPC peering connection whose data will be exported as attributes.
+
+* `region` - (Optional, String) The region in which to obtain the VPC Peering Connection. If omitted, the provider-level
+  region will be used.
+
+* `id` - (Optional, String) The ID of the specific VPC Peering Connection to retrieve.
+
+* `name` - (Optional, String) The name of the specific VPC Peering Connection to retrieve.
+
+* `status` - (Optional, String) The status of the specific VPC Peering Connection to retrieve.
+
+* `vpc_id` - (Optional, String) The ID of the requester VPC of the specific VPC Peering Connection to retrieve.
+
+* `peer_vpc_id` - (Optional, String) The ID of the accepter/peer VPC of the specific VPC Peering Connection to retrieve.
+
+* `peer_tenant_id` - (Optional, String) The Tenant ID of the accepter/peer VPC of the specific VPC Peering Connection to
+  retrieve.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `description` - The description of the VPC Peering Connection.

--- a/docs/data-sources/vpcs.md
+++ b/docs/data-sources/vpcs.md
@@ -1,0 +1,70 @@
+---
+subcategory: "Virtual Private Cloud (VPC)"
+---
+
+# hcso_vpcs
+
+Use this data source to get a list of VPC.
+
+## Example Usage
+
+An example filter by name and tag
+
+```hcl
+variable "vpc_name" {}
+
+data "hcso_vpcs" "vpc" {
+  name = var.vpc_name
+
+  tags = {
+    foo = "bar"
+  }
+}
+
+output "vpc_ids" {
+  value = data.hcso_vpcs.vpc.vpcs[*].id
+}
+```
+
+## Argument Reference
+
+The arguments of this data source act as filters for querying the available VPCs in the current region.
+ All VPCs that meet the filter criteria will be exported as attributes.
+
+* `region` - (Optional, String) Specifies the region in which to obtain the VPC. If omitted, the provider-level region
+  will be used.
+
+* `id` - (Optional, String) Specifies the id of the desired VPC.
+
+* `name` - (Optional, String) Specifies the name of the desired VPC. The value is a string of no more than 64 characters
+  and can contain digits, letters, underscores (_) and hyphens (-).
+
+* `status` - (Optional, String) Specifies the current status of the desired VPC. The value can be CREATING, OK or ERROR.
+
+* `cidr` - (Optional, String) Specifies the cidr block of the desired VPC.
+
+* `enterprise_project_id` - (Optional, String) Specifies the enterprise project ID which the desired VPC belongs to.
+
+* `tags` - (Optional, Map) Specifies the included key/value pairs which associated with the desired VPC.
+
+ -> A maximum of 10 tag keys are allowed for each query operation. Each tag key can have up to 10 tag values.
+  The tag key cannot be left blank or set to an empty string. Each tag key must be unique, and each tag value in a
+  tag must be unique, use commas(,) to separate the multiple values. An empty for values indicates any value.
+  The values are in the OR relationship.
+
+## Attribute Reference
+
+The following attributes are exported:
+
+* `id` - Indicates a data source ID.
+* `vpcs` - Indicates a list of all VPCs found. Structure is documented below.
+
+The `vpcs` block supports:
+
+* `id` - Indicates the ID of the VPC.
+* `name` - Indicates the name of the VPC.
+* `cidr` - Indicates the cidr block of the VPC.
+* `status` - Indicates the current status of the VPC.
+* `enterprise_project_id` - Indicates the the enterprise project ID of the VPC.
+* `description` - Indicates the description of the VPC.
+* `tags` - Indicates the key/value pairs which associated with the VPC.

--- a/docs/resources/networking_secgroup.md
+++ b/docs/resources/networking_secgroup.md
@@ -1,0 +1,110 @@
+---
+subcategory: "Virtual Private Cloud (VPC)"
+---
+
+# hcso_networking_secgroup
+
+Manages a Security Group resource within Huawei Cloud Stack Online.
+
+## Example Usage
+
+```hcl
+resource "hcso_networking_secgroup" "secgroup" {
+  name        = "secgroup_1"
+  description = "My security group"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) The region in which to create the security group resource. If omitted, the
+  provider-level region will be used. Changing this creates a new security group resource.
+
+* `name` - (Required, String) Specifies a unique name for the security group.
+
+* `description` - (Optional, String) Specifies the description for the security group.
+
+* `enterprise_project_id` - (Optional, String, ForceNew) Specifies the enterprise project id of the security group.
+  Changing this creates a new security group.
+
+* `delete_default_rules` - (Optional, Bool, ForceNew) Specifies whether or not to delete the default security rules.
+  This is `false` by default.
+
+-> **NOTE:** The default security rules are described
+in [HuaweiCloud](https://support.huaweicloud.com/intl/en-us/usermanual-vpc/SecurityGroup_0003.html). See the below
+section for more information.
+
+## Default Security Group Rules
+
+In most cases, Huawei Cloud Stack will create some security group rules for each new security group.
+These security group rules will not be managed by Terraform, so if you prefer to have *all*
+aspects of your infrastructure managed by Terraform, set `delete_default_rules` to `true`
+and then create separate security group rules such as the following:
+
+```hcl
+resource "hcso_networking_secgroup_rule" "secgroup_rule_v4" {
+  security_group_id = hcso_networking_secgroup.secgroup.id
+  direction         = "egress"
+  ethertype         = "IPv4"
+}
+
+resource "hcso_networking_secgroup_rule" "secgroup_rule_v6" {
+  security_group_id = hcso_networking_secgroup.secgroup.id
+  direction         = "egress"
+  ethertype         = "IPv6"
+}
+
+resource "hcso_networking_secgroup_rule" "allow_ssh" {
+  security_group_id = hcso_networking_secgroup.secgroup.id
+  direction         = "ingress"
+  ethertype         = "IPv4"
+  protocol          = "tcp"
+  port_range_min    = 22
+  port_range_max    = 22
+  remote_ip_prefix  = "0.0.0.0/0"
+}
+```
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID in UUID format.
+
+* `rules` - The array of security group rules associating with the security group.
+  The [rule object](#security_group_rule) is documented below.
+
+* `created_at` - The creation time, in UTC format.
+
+* `updated_at` - The last update time, in UTC format.
+
+<a name="security_group_rule"></a>
+The `rules` block supports:
+
+* `id` - The security group rule ID.
+* `description` - The supplementary information about the security group rule.
+* `direction` - The direction of the rule. The value can be *egress* or *ingress*.
+* `ethertype` - The IP protocol version. The value can be *IPv4* or *IPv6*.
+* `protocol` - The protocol type.
+* `ports` - The port value range.
+* `remote_ip_prefix` - The remote IP address. The value can be in the CIDR format or IP addresses.
+* `remote_group_id` - The ID of the peer security group.
+* `remote_address_group_id` - The ID of the remote address group.
+* `action` - The effective policy.
+* `priority` - The priority number.
+
+## Timeouts
+
+This resource provides the following timeouts configuration options:
+
+* `delete` - Default is 10 minutes.
+
+## Import
+
+Security Groups can be imported using the `id`, e.g.
+
+```
+$ terraform import hcso_networking_secgroup.secgroup_1 38809219-5e8a-4852-9139-6f461c90e8bc
+```

--- a/docs/resources/networking_secgroup_rule.md
+++ b/docs/resources/networking_secgroup_rule.md
@@ -1,0 +1,127 @@
+---
+subcategory: "Virtual Private Cloud (VPC)"
+---
+
+# hcso_networking_secgroup_rule
+
+Manages a Security Group Rule resource within Huawei Cloud Stack Online.
+
+## Example Usage
+
+### Create an ingress rule that opens TCP port 8080 with port range parameters
+
+```hcl
+variable "security_group_id" {}
+
+resource "hcso_networking_secgroup_rule" "test" {
+  security_group_id = var.security_group_id
+  direction         = "ingress"
+  ethertype         = "IPv4"
+  protocol          = "tcp"
+  port_range_min    = 8080
+  port_range_max    = 8080
+  remote_ip_prefix  = "0.0.0.0/0"
+}
+```
+
+### Create an ingress rule that enable the remote address group and open some TCP ports
+
+```hcl
+variable "group_name" {}
+variable "security_group_id" {}
+
+resource "hcso_vpc_address_group" "test" {
+  name = var.group_name
+
+  addresses = [
+    "192.168.10.12",
+    "192.168.11.0-192.168.11.240",
+  ]
+}
+
+resource "hcso_networking_secgroup_rule" "test" {
+  security_group_id       = var.security_group_id
+  direction               = "ingress"
+  action                  = "allow"
+  ethertype               = "IPv4"
+  ports                   = "80,500,600-800"
+  protocol                = "tcp"
+  priority                = 5
+  remote_address_group_id = hcso_vpc_address_group.test.id
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region in which to create the security group rule resource. If
+  omitted, the provider-level region will be used. Changing this creates a new security group rule.
+
+* `security_group_id` - (Required, String, ForceNew) Specifies the security group ID the rule should belong to. Changing
+  this creates a new security group rule.
+
+* `direction` - (Required, String, ForceNew) Specifies the direction of the rule, valid values are **ingress** or
+  **egress**. Changing this creates a new security group rule.
+
+* `ethertype` - (Required, String, ForceNew) Specifies the layer 3 protocol type, valid values are **IPv4** or **IPv6**.
+  Changing this creates a new security group rule.
+
+* `description` - (Optional, String, ForceNew) Specifies the supplementary information about the networking security
+  group rule. This parameter can contain a maximum of 255 characters and cannot contain angle brackets (< or >).
+  Changing this creates a new security group rule.
+
+* `protocol` - (Optional, String, ForceNew) Specifies the layer 4 protocol type, valid values are **tcp**, **udp**,
+  **icmp** and **icmpv6**. If omitted, the protocol means that all protocols are supported.
+  This is required if you want to specify a port range. Changing this creates a new security group rule.
+
+* `port_range_min` - (Optional, Int, ForceNew) Specifies the lower part of the allowed port range, valid integer value
+  needs to be between `1` and `65,535`. Changing this creates a new security group rule.
+  This parameter and `ports` are alternative.
+
+* `port_range_max` - (Optional, Int, ForceNew) Specifies the higher part of the allowed port range, valid integer value
+  needs to be between `1` and `65,535`. Changing this creates a new security group rule.
+  This parameter and `ports` are alternative.
+
+* `ports` - (Optional, String, ForceNew) Specifies the allowed port value range, which supports single port (80),
+  continuous port (1-30) and discontinous port (22, 3389, 80) The valid port values is range form `1` to `65,535`.
+  Changing this creates a new security group rule.
+
+* `remote_ip_prefix` - (Optional, String, ForceNew) Specifies the remote CIDR, the value needs to be a valid CIDR (i.e.
+  192.168.0.0/16). Changing this creates a new security group rule.
+
+* `remote_group_id` - (Optional, String, ForceNew) Specifies the remote group ID. Changing this creates a new security
+  group rule.
+
+* `remote_address_group_id` - (Optional, String, ForceNew) Specifies the remote address group ID.
+  This parameter is not used with `port_range_min` and `port_range_max`.
+  Changing this creates a new security group rule.
+
+* `action` - (Optional, String, ForceNew) Specifies the effective policy. The valid values are **allow** and **deny**.
+  This parameter is not used with `port_range_min` and `port_range_max`.
+  Changing this creates a new security group rule.
+
+* `priority` - (Optional, Int, ForceNew) Specifies the priority number.
+  The valid value is range from **1** to **100**. The default value is **1**.
+  This parameter is not used with `port_range_min` and `port_range_max`.
+  Changing this creates a new security group rule.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID in UUID format.
+
+## Timeouts
+
+This resource provides the following timeouts configuration options:
+
+* `delete` - Default is 10 minutes.
+
+## Import
+
+Security Group Rules can be imported using the `id`, e.g.
+
+```
+$ terraform import hcso_networking_secgroup_rule.secgroup_rule_1 aeb68ee3-6e9d-4256-955c-9584a6212745
+```

--- a/docs/resources/networking_vip.md
+++ b/docs/resources/networking_vip.md
@@ -1,0 +1,64 @@
+---
+subcategory: "Virtual Private Cloud (VPC)"
+---
+
+# hcso_networking_vip
+
+Manages a network VIP resource within Huawei Cloud Stack Online VPC.
+
+## Example Usage
+
+```hcl
+resource "hcso_vpc_subnet" "test" {
+  ...
+}
+
+resource "hcso_networking_vip" "test" {
+  network_id = hcso_vpc_subnet.test.id
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region in which to create the VIP.
+  If omitted, the provider-level region will be used. Changing this will create a new VIP resource.
+
+* `network_id` - (Required, String, ForceNew) Specifies the network ID of the VPC subnet to which the VIP belongs.
+  Changing this will create a new VIP resource.
+
+* `ip_version` - (Optional, Int, ForceNew) Specifies the IP version, either `4` (default) or `6`.
+  Changing this will create a new VIP resource.
+
+* `ip_address` - (Optional, String, ForceNew) Specifies the IP address desired in the subnet for this VIP.
+  Changing this will create a new VIP resource.
+
+* `name` - (Optional, String) Specifies a unique name for the VIP.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The VIP ID.
+
+* `mac_address` - The MAC address of the VIP.
+
+* `status` - The VIP status.
+
+* `device_owner` - The device owner of the VIP.
+
+## Timeouts
+
+This resource provides the following timeouts configuration options:
+
+* `create` - Default is 2 minute.
+* `delete` - Default is 2 minute.
+
+## Import
+
+Network VIPs can be imported using their `id`, e.g.:
+
+```
+$ terraform import hcso_networking_vip.test ce595799-da26-4015-8db5-7733c6db292e
+```

--- a/docs/resources/vpc_address_group.md
+++ b/docs/resources/vpc_address_group.md
@@ -1,0 +1,103 @@
+---
+subcategory: "Virtual Private Cloud (VPC)"
+---
+
+# hcso_vpc_address_group
+
+Manages a VPC IP address group resource within Huawei Cloud Stack Online.
+
+## Example Usage
+
+### IPv4 Address Group
+
+```hcl
+resource "hcso_vpc_address_group" "ipv4" {
+  name = "group-ipv4"
+
+  addresses = [
+    "192.168.10.10",
+    "192.168.1.1-192.168.1.50"
+  ]
+}
+```
+
+### IPv6 Address Group
+
+```hcl
+resource "hcso_vpc_address_group" "ipv6" {
+  name       = "group-ipv6"
+  ip_version = 6
+
+  addresses = [
+    "2001:db8:a583:6e::/64"
+  ]
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region in which to create the IP address group. If omitted, the
+  provider-level region will be used. Changing this creates a new address group.
+  
+* `name` - (Required, String) Specifies the IP address group name. The value is a string of 1 to 64 characters that can contain
+  letters, digits, underscores (_), hyphens (-) and periods (.).
+
+* `addresses` - (Required, List) Specifies an array of one or more IP addresses. The address can be a single IP
+  address, IP address range or IP address CIDR. The maximum length is 20.
+
+* `ip_version` - (Optional, Int, ForceNew) Specifies the IP version, either `4` (default) or `6`.
+  Changing this creates a new address group.
+
+* `description` - (Optional, String) Specifies the supplementary information about the IP address group.
+  The value is a string of no more than 255 characters and cannot contain angle brackets (< or >).
+
+* `max_capacity` - (Optional, Int) Specifies the maximum number of addresses that an address group can contain.
+  Value range: **1**-**20**, the default value is **20**.
+
+* `enterprise_project_id` - (Optional, String, ForceNew) Specifies the enterprise project ID.
+  Changing this creates a new address group.
+
+* `force_destroy` - (Optional, Bool) Specifies whether to forcibly destroy the address group if it is associated with
+  a security group rule, the address group and the associated security group rule will be deleted together.
+  The default value is **false**.
+  
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID in UUID format.
+
+## Timeouts
+
+This resource provides the following timeouts configuration options:
+
+* `create` - Default is 5 minutes.
+* `update` - Default is 5 minutes.
+* `delete` - Default is 5 minutes.
+
+## Import
+
+IP address groups can be imported using the `id`, e.g.
+
+```bash
+$ terraform import hcso_vpc_address_group.test bc96f6b0-ca2c-42ee-b719-0f26bc9c8661
+```
+
+Note that the imported state may not be identical to your resource definition, due to some attributes missing from the
+API response. The missing attributes include: `force_destroy`. It is generally recommended running `terraform plan` after
+importing the image. You can then decide if changes should be applied to the image, or the resource
+definition should be updated to align with the image. Also you can ignore changes as below.
+
+```hcl
+resource "hcso_vpc_address_group" "test" {
+  ...
+
+  lifecycle {
+    ignore_changes = [
+      force_destroy,
+    ]
+  }
+}
+```

--- a/docs/resources/vpc_peering_connection.md
+++ b/docs/resources/vpc_peering_connection.md
@@ -1,0 +1,68 @@
+---
+subcategory: "Virtual Private Cloud (VPC)"
+---
+
+# hcso_vpc_peering_connection
+
+Provides a resource to manage a VPC Peering Connection resource.
+
+-> **NOTE:** For cross-tenant (requester's tenant differs from the accepter's tenant) VPC Peering Connections,
+  use the `hcso_vpc_peering_connection` resource to manage the requester's side of the connection and
+  use the `hcso_vpc_peering_connection_accepter` resource to manage the accepter's side of the connection.
+  <br/>If you create a VPC peering connection with another VPC of your own, the connection is created without the need
+  for you to accept the connection.
+
+## Example Usage
+
+ ```hcl
+resource "hcso_vpc_peering_connection" "peering" {
+  name        = var.peer_conn_name
+  vpc_id      = var.vpc_id
+  peer_vpc_id = var.accepter_vpc_id
+}
+ ```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) The region in which to create the VPC peering connection. If omitted, the
+  provider-level region will be used. Changing this creates a new VPC peering connection resource.
+
+* `name` - (Required, String) Specifies the name of the VPC peering connection. The value can contain 1 to 64
+  characters.
+
+* `vpc_id` - (Required, String, ForceNew) Specifies the ID of a VPC involved in a VPC peering connection. Changing this
+  creates a new VPC peering connection.
+
+* `peer_vpc_id` - (Required, String, ForceNew) Specifies the VPC ID of the accepter tenant. Changing this creates a new
+  VPC peering connection.
+
+* `peer_tenant_id` - (Optional, String, ForceNew) Specifies the tenant ID of the accepter tenant. Changing this creates
+  a new VPC peering connection.
+
+* `description` - (Optional, String) Specifies the description of the VPC peering connection.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The VPC peering connection ID.
+
+* `status` - The VPC peering connection status. The value can be PENDING_ACCEPTANCE, REJECTED, EXPIRED, DELETED, or
+  ACTIVE.
+
+## Timeouts
+
+This resource provides the following timeouts configuration options:
+
+* `create` - Default is 10 minutes.
+* `delete` - Default is 10 minutes.
+
+## Import
+
+VPC Peering resources can be imported using the `vpc peering id`, e.g.
+
+```
+$ terraform import hcso_vpc_peering_connection.test_connection 22b76469-08e3-4937-8c1d-7aad34892be1
+```

--- a/docs/resources/vpc_peering_connection_accepter.md
+++ b/docs/resources/vpc_peering_connection_accepter.md
@@ -1,0 +1,99 @@
+---
+subcategory: "Virtual Private Cloud (VPC)"
+---
+
+# hcso_vpc_peering_connection_accepter
+
+Provides a resource to manage the accepter's side of a VPC Peering Connection.
+
+-> **NOTE:** When a cross-tenant (requester's tenant differs from the accepter's tenant) VPC Peering Connection
+  is created, a VPC Peering Connection resource is automatically created in the accepter's account.
+  The requester can use the `hcso_vpc_peering_connection` resource to manage its side of the connection and
+  the accepter can use the `hcso_vpc_peering_connection_accepter` resource to accept its side of the connection
+  into management.
+
+## Example Usage
+
+```hcl
+provider "hcso" {
+  alias = "main"
+}
+
+provider "hcso" {
+  alias = "peer"
+}
+
+resource "hcso_vpc" "vpc_main" {
+  provider = "hcso.main"
+  name     = var.vpc_name
+  cidr     = var.vpc_cidr
+}
+
+resource "hcso_vpc" "vpc_peer" {
+  provider = "hcso.peer"
+  name     = var.peer_vpc_name
+  cidr     = var.peer_vpc_cidr
+}
+
+# Requester's side of the connection.
+resource "hcso_vpc_peering_connection" "peering" {
+  provider       = "hcso.main"
+  name           = var.peer_name
+  vpc_id         = hcso_vpc.vpc_main.id
+  peer_vpc_id    = hcso_vpc.vpc_peer.id
+  peer_tenant_id = var.tenant_id
+}
+
+# Accepter's side of the connection.
+resource "hcso_vpc_peering_connection_accepter" "peer" {
+  provider = "hcso.peer"
+  accept   = true
+
+  vpc_peering_connection_id = hcso_vpc_peering_connection.peering.id
+}
+ ```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) The region in which to create the vpc peering connection accepter. If omitted,
+  the provider-level region will be used. Changing this creates a new VPC peering connection accepter resource.
+
+* `vpc_peering_connection_id` - (Required, String, ForceNew) The VPC Peering Connection ID to manage. Changing this
+  creates a new VPC peering connection accepter.
+
+* `accept` - (Optional, Bool) Whether or not to accept the peering request. Defaults to `false`.
+
+## Removing hcso_vpc_peering_connection_accepter from your configuration
+
+Huawei Cloud Stack Online allows a cross-tenant VPC Peering Connection to be deleted from either the requester's or
+accepter's side. However, Terraform only allows the VPC Peering Connection to be deleted from the requester's side
+by removing the corresponding `hcso_vpc_peering_connection` resource from your configuration.
+Removing a `hcso_vpc_peering_connection_accepter` resource from your configuration will remove it from your
+state file and management, but will not destroy the VPC Peering Connection.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The VPC peering connection ID.
+
+* `name` - The VPC peering connection name.
+
+* `status` - The VPC peering connection status.
+
+* `description` - The description of the VPC peering connection.
+
+* `vpc_id` - The ID of requester VPC involved in a VPC peering connection.
+
+* `peer_vpc_id` - The VPC ID of the accepter tenant.
+
+* `peer_tenant_id` - The Tenant Id of the accepter tenant.
+
+## Timeouts
+
+This resource provides the following timeouts configuration options:
+
+* `create` - Default is 10 minutes.
+* `delete` - Default is 10 minutes.

--- a/internal/provider.go
+++ b/internal/provider.go
@@ -299,9 +299,13 @@ func Provider() *schema.Provider {
 
 			"hcso_evs_volumes": evs.DataSourceEvsVolumesV2(),
 
-			"hcso_vpc":            vpc.DataSourceVpcV1(),
-			"hcso_vpc_subnets":    vpc.DataSourceVpcSubnets(),
-			"hcso_vpc_subnet_ids": vpc.DataSourceVpcSubnetIdsV1(),
+			"hcso_vpc":                    vpc.DataSourceVpcV1(),
+			"hcso_vpcs":                   vpc.DataSourceVpcs(),
+			"hcso_vpc_subnet_ids":         vpc.DataSourceVpcSubnetIdsV1(),
+			"hcso_vpc_subnets":            vpc.DataSourceVpcSubnets(),
+			"hcso_networking_port":        vpc.DataSourceNetworkingPortV2(),
+			"hcso_vpc_peering_connection": vpc.DataSourceVpcPeeringConnectionV2(),
+			"hcso_networking_secgroups":   vpc.DataSourceNetworkingSecGroups(),
 		},
 
 		ResourcesMap: map[string]*schema.Resource{
@@ -315,8 +319,14 @@ func Provider() *schema.Provider {
 			"hcso_images_image_share":          ims.ResourceImsImageShare(),
 			"hcso_images_image_share_accepter": ims.ResourceImsImageShareAccepter(),
 
-			"hcso_vpc":        vpc.ResourceVirtualPrivateCloudV1(),
-			"hcso_vpc_subnet": vpc.ResourceVpcSubnetV1(),
+			"hcso_vpc":                             vpc.ResourceVirtualPrivateCloudV1(),
+			"hcso_vpc_address_group":               vpc.ResourceVpcAddressGroup(),
+			"hcso_vpc_subnet":                      vpc.ResourceVpcSubnetV1(),
+			"hcso_vpc_peering_connection":          vpc.ResourceVpcPeeringConnectionV2(),
+			"hcso_vpc_peering_connection_accepter": vpc.ResourceVpcPeeringConnectionAccepterV2(),
+			"hcso_networking_secgroup":             vpc.ResourceNetworkingSecGroup(),
+			"hcso_networking_secgroup_rule":        vpc.ResourceNetworkingSecGroupRule(),
+			"hcso_networking_vip":                  vpc.ResourceNetworkingVip(),
 		},
 	}
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
add vpc secgroup resource and datasource support.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
add vpc secgroup resource and datasource support.
```

## PR Checklist

* [x] Tests added/passed.
* [x] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./internal' TESTARGS='-run=TestAccVpcAddressGroup_basic '
...
=== RUN   TestAccVpcAddressGroup_basic 
--- PASS: TestAccVpcAddressGroup_basic (31.01s)
PASS

=== RUN   TestAccNetworkingV3SecGroup_basic 
--- PASS: TestAccNetworkingV3SecGroup_basic  (52.94s)
PASS

=== RUN   TestAccVpcsDataSource_basic 
--- PASS: TestAccVpcsDataSource_basic (30.44s)
PASS

=== RUN   TestAccVpcPeeringConnectionAccepter_basic 
--- PASS: TestAccVpcPeeringConnectionAccepter_basic (44.15s)
PASS

=== RUN   TestAccVpcPeeringConnectionDataSource_basic 
--- PASS: TestAccVpcPeeringConnectionDataSource_basic  (68.42s)
PASS

=== RUN   TestAccNetworkingV2PortDataSource_basic
--- PASS: TestAccNetworkingV2PortDataSource_basic(34.51s)
PASS
```
